### PR TITLE
Update region :background variable

### DIFF
--- a/everforest-hard-dark-theme.el
+++ b/everforest-hard-dark-theme.el
@@ -76,7 +76,7 @@
    `(link-visited        ((t (:foreground ,everforest-hard-dark-blue :underline t :weight normal))))
    `(cursor              ((t (:background ,everforest-hard-dark-fg))))
    `(fringe              ((t (:background ,everforest-hard-dark-bg :foreground ,everforest-hard-dark-silver))))
-   `(region              ((t (:background ,everforest-hard-dark-gray :distant-foreground ,everforest-hard-dark-mono-2))))
+   `(region              ((t (:background ,everforest-hard-dark-gutter :distant-foreground ,everforest-hard-dark-mono-2))))
    `(highlight           ((t (:background ,everforest-hard-dark-gray :distant-foreground ,everforest-hard-dark-mono-2))))
    `(hl-line             ((t (:background ,everforest-hard-dark-visual :distant-foreground nil))))
    `(header-line         ((t (:background ,everforest-hard-dark-black))))


### PR DESCRIPTION
Changed the region:background variable from everforest-hard-dark-gray to everforest-hard-dark-gutter. The previous gray color was also used for highlighting the current line. Thus, within evil's visual mode, it was difficult to distinguish whether the line was selected or highlighted. By switching the background color of the region to gutter, we enhance the contrast and provide a clearer indication of the currently selected lines. Now, in evil, if we switch to visual mode, the selected characters are highlighted more promptly.