### PR TITLE
Fix: `doom sync` crashing

### DIFF
--- a/everforest.el
+++ b/everforest.el
@@ -2,10 +2,10 @@
 ;;
 ;; Copyright (C) 2022 Evan Sarris
 ;;
-;;;  Author: Theory_of_Everything <evan@theoryware.net>
-;;;  Version: 0.1
-;;;  Homepage: https://git.sr.ht/~theorytoe/everforest-theme
-;;;  Package-Requires: ((emacs "24"))
+;;  Author: Theory_of_Everything <evan@theoryware.net>
+;;  Version: 0.1
+;;  Homepage: https://git.sr.ht/~theorytoe/everforest-theme
+;;  Package-Requires: ((emacs "24"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;

--- a/everforest.el
+++ b/everforest.el
@@ -28,5 +28,5 @@
 ;; 		  (file-name-as-directory
 ;; 		   (file-name-directory load-file-name))))
 
-;; (provide 'everforest-theme)
+(provide 'everforest-theme)
 ;;; everforest.el ends here


### PR DESCRIPTION
When adding this theme to doom emacs as documented in the README, `doom sync` crashed upon building the theme. Apparently, the problem was that `everforest.el` had no code in it, and probably that the package was not registered. I found some TODOs in there for better handling of the package metadata and my fix is probably not the best one with respect to that. I suppose its better to have a working package though with some open TODOs than a broken one.